### PR TITLE
fixed height mismatch between characters and rows

### DIFF
--- a/newstyle.css
+++ b/newstyle.css
@@ -79,7 +79,7 @@ td {
 	margin: 0;
 	padding: 0;
 	width: 100%;
-	height: 64px;
+	height: 66px;
 }
 
 tr {
@@ -140,7 +140,7 @@ table {
 }
 
 .tier {
-	min-height: 64px;
+	min-height: 66px;
 	text-align: left;
 }
 


### PR DESCRIPTION
the characters have a pagging which makes their total height 66px while
the rows have a default height of 64px. This leads to changes in the
size of the rows as soon as you add the first character to an empty row.